### PR TITLE
解决issue1问题

### DIFF
--- a/uiDesign.pro.user
+++ b/uiDesign.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 12.0.1, 2024-07-16T22:53:49. -->
+<!-- Written by QtCreator 12.0.1, 2024-07-18T12:20:12. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>

--- a/uidesign.h
+++ b/uidesign.h
@@ -152,7 +152,7 @@ private slots:
     QString FilterCoursesByInput(QString table,QString institute,QString coursename,QString teacher,QString coursetype,QString coursecode,QString week,QString period);
     int getCourseChosenAmount(QString courseid);
 
-    void showNoice(QTableWidget* table);
+    void showNoice(QTableWidget* table,QString userID);//修改
     void fixPasskey(QSqlQuery &Query,QString passkey,QString table,QString IDname);
 
     void on_toolButton_released();


### PR DESCRIPTION
在查看详情按钮的右上角添加一个用于识别是否已读的标识，但是由于表格的生成是依赖于数据库，因此想要添加该功能需要在公告信息中添加可以识别是否已读的信息。由于每个学生已读的状态均可能不同，因此理论上每个学生应该独自维护一个已读未读表，因此原本的存放公告的数据库应该设计一个ID用来唯一确定公告，新建一个isread的数据表用于保存已读对应公告的人员。添加数据表同时还要在代码逻辑上加上判断是否已读的判断。主要的代码逻辑实现在展示表格的函数中：
![image](https://github.com/user-attachments/assets/c27e6e1d-255b-44fa-88ed-e551fc48ce19)
![image](https://github.com/user-attachments/assets/115a3a56-9476-46af-9426-c0cba9349f9e)
由于需要登录的用户的账号用于记录已读信息，参数传递的原来的基础上也做了一定调整。加上了账号信息，其他地方调用该函数也对应的需要添加参数。
由此就可以解决公告读取的状态，最终的效果如下图：
![image](https://github.com/user-attachments/assets/1e4f8f06-bfe6-43d0-b4f7-51ff497206c6)